### PR TITLE
fix: Validates path params at startup

### DIFF
--- a/packages/flink/src/utils.ts
+++ b/packages/flink/src/utils.ts
@@ -88,3 +88,15 @@ export function getJsDocComment(comment: string) {
 
     return rows.join("\n").trim();
 }
+
+const pathParamsRegex = /:([a-zA-Z0-9]+)/g;
+
+/**
+ * Returns array of path params from path string.
+ * For example `/user/:id` will return `["id"]`
+ * @param path
+ * @returns
+ */
+export function getPathParams(path: string) {
+    return path.match(pathParamsRegex)?.map((match) => match.slice(1)) || [];
+}


### PR DESCRIPTION
Will match path in route props with
parameter types and either throw error
or log warning when app starts.

So for example if handler has path `/foo/:bar/:baz` and type

```typescript
type Params = {
   bar: string;
  // baz: string is missing
}
```

it will throw an error.