### PR TITLE
[ HOTFIX ] fix onSucessfulLogin callback if project uses multiple auth plugins

### DIFF
--- a/packages/generic-auth-plugin/src/handlers/UserLogin.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserLogin.ts
@@ -19,7 +19,7 @@ const userLoginHandler: Handler<
     req.body.password,
     ctx.plugins.genericAuthPlugin.validatePasswordMethod,
     (<any>ctx.plugins)[pluginName].smsOptions,
-    ctx.plugins.genericAuthPlugin.onSuccessfulLogin
+    (<any>ctx.plugins)[pluginName].onSuccessfulLogin
   );
 
   if (loginRespons.status != "success") {


### PR DESCRIPTION
If project used auth plugin multiple times, initiation of the latest plugin would overwrite the previous onSuccessfulLogin callback, so all plugins would use same callback, leading to confusing errors.