### PR TITLE
feat: Config to restrict to one register device for push

### DIFF
--- a/packages/generic-auth-plugin/src/genericAuthPluginOptions.ts
+++ b/packages/generic-auth-plugin/src/genericAuthPluginOptions.ts
@@ -32,6 +32,12 @@ export interface GenericAuthPluginOptions {
      * deregistered.
      */
     deregisterOtherDevices?: boolean;
+
+    /**
+     * If true, multiple devices can be registered with the same `deviceId`.
+     * Default is `true`.
+     */
+    allowMultipleDevices?: boolean;
 }
 
 export interface GenericAuthsmsOptions {

--- a/packages/generic-auth-plugin/src/handlers/UserPushRegisterToken.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserPushRegisterToken.ts
@@ -32,7 +32,7 @@ const postUserPushRegisterTokenHandler: Handler<FlinkContext<genericAuthContext>
 
     if (!allowMultipleDevices) {
         // Filter out all other devices except the newly registered one
-        user.pushNotificationTokens = user.pushNotificationTokens.filter((t) => t.deviceId !== req.body.deviceId);
+        user.pushNotificationTokens = user.pushNotificationTokens.filter((t) => t.deviceId === req.body.deviceId);
     }
 
     await repo.updateOne(user._id, {

--- a/packages/generic-auth-plugin/src/handlers/UserPushRegisterToken.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserPushRegisterToken.ts
@@ -14,6 +14,7 @@ const postUserPushRegisterTokenHandler: Handler<FlinkContext<genericAuthContext>
     const pluginOptions: GenericAuthPluginOptions = (ctx.plugins as any)[pluginName];
     const repo = ctx.repos[pluginOptions.repoName];
     const deregisterOtherDevices = pluginOptions.deregisterOtherDevices || false;
+    const allowMultipleDevices = pluginOptions.allowMultipleDevices ?? true;
 
     const user = <User>await repo.getById(req.user._id);
 
@@ -27,6 +28,11 @@ const postUserPushRegisterTokenHandler: Handler<FlinkContext<genericAuthContext>
         exToken.token = req.body.token;
     } else {
         user.pushNotificationTokens.push(req.body);
+    }
+
+    if (!allowMultipleDevices) {
+        // Filter out all other devices except the newly registered one
+        user.pushNotificationTokens = user.pushNotificationTokens.filter((t) => t.deviceId !== req.body.deviceId);
     }
 
     await repo.updateOne(user._id, {


### PR DESCRIPTION
Adds `allowMultipleDevices` to restrict to one device only.

Is true by default (non breaking change).