### PR TITLE
fix: allow id as ObjectID and string

### DIFF
--- a/packages/flink/spec/FlinkRepo.spec.ts
+++ b/packages/flink/spec/FlinkRepo.spec.ts
@@ -2,61 +2,59 @@ import { FlinkRepo } from "../src/FlinkRepo";
 import mongodb, { Collection, Db } from "mongodb";
 
 interface Model {
-  _id: string;
-  name: string;
+    _id: string;
+    name: string;
 }
 
 class Repo extends FlinkRepo<any, Model> {}
 
 describe("FlinkRepo", () => {
-  if (!process.env.CI) {
-    console.warn("Skipping repo test which requires db if CI flag is not set");
-    return;
-  }
+    if (!process.env.CI) {
+        console.warn("Skipping repo test which requires db if CI flag is not set");
+        return;
+    }
 
-  let db: Db;
-  let collection: Collection;
-  let repo: Repo;
+    let db: Db;
+    let collection: Collection;
+    let repo: Repo;
 
-  beforeAll(async () => {
-    const client = await mongodb.connect(
-      "mongodb://localhost:27017/flink-test-db"
-    );
-    db = client.db();
-    collection = db.collection("test-coll");
+    beforeAll(async () => {
+        const client = await mongodb.connect("mongodb://localhost:27017/flink-test-db");
+        db = client.db();
+        collection = db.collection("test-coll");
 
-    repo = new Repo("test-coll", db);
-  });
-
-  it("should get document by id", async () => {
-    const { insertedId } = await collection.insertOne({ name: "foo" });
-
-    const doc = await repo.getById(insertedId + "");
-
-    expect(doc).toBeDefined();
-    expect(doc?.name).toBe("foo");
-  });
-
-  it("should create and delete document", async () => {
-    const createdDoc = await repo.create<{ name: string }>({ name: "bar" });
-
-    expect(createdDoc).toBeDefined();
-    expect(createdDoc?._id).toBeDefined();
-    expect(createdDoc?.name).toBe("bar");
-
-    const delCount = await repo.deleteById(createdDoc._id);
-
-    expect(delCount).toBe(1);
-  });
-
-  it("should update document", async () => {
-    const createdDoc = await repo.create({ name: "bar" });
-
-    const updatedDoc = await repo.updateOne(createdDoc._id + "", {
-      name: "foo",
+        repo = new Repo("test-coll", db);
     });
 
-    expect(updatedDoc).toBeDefined();
-    expect(updatedDoc.name).toBe("foo");
-  });
+    it("should get document by id", async () => {
+        const { insertedId } = await collection.insertOne({ name: "foo" });
+
+        const doc = await repo.getById(insertedId + "");
+
+        expect(doc).toBeDefined();
+        expect(doc?.name).toBe("foo");
+    });
+
+    it("should create and delete document", async () => {
+        const createdDoc = await repo.create<{ name: string }>({ name: "bar" });
+
+        expect(createdDoc).toBeDefined();
+        expect(createdDoc?._id).toBeDefined();
+        expect(createdDoc?.name).toBe("bar");
+
+        const delCount = await repo.deleteById(createdDoc._id);
+
+        expect(delCount).toBe(1);
+    });
+
+    it("should update document", async () => {
+        const createdDoc = await repo.create({ name: "bar" });
+
+        const updatedDoc = await repo.updateOne(createdDoc._id + "", {
+            name: "foo",
+        });
+
+        expect(updatedDoc).toBeDefined();
+        expect(updatedDoc.name).toBe("foo");
+    });
 });

--- a/packages/flink/src/FlinkRepo.ts
+++ b/packages/flink/src/FlinkRepo.ts
@@ -68,11 +68,13 @@ export abstract class FlinkRepo<C extends FlinkContext, Model = any> {
         let oid: ObjectId | string;
 
         if (typeof id === "string") {
-            oid = ObjectId.isValid(id) ? new ObjectId(id) : id;
+            oid = new ObjectId(id);
         } else if (id instanceof ObjectId) {
             oid = id;
         } else {
             throw new Error("Invalid id type");
         }
+
+        return oid;
     }
 }

--- a/packages/flink/src/FlinkRepo.ts
+++ b/packages/flink/src/FlinkRepo.ts
@@ -1,66 +1,78 @@
-import { Collection, Db, ObjectID } from "mongodb";
+import { Collection, Db, ObjectId } from "mongodb";
 import { FlinkContext } from "./FlinkContext";
 
 export abstract class FlinkRepo<C extends FlinkContext, Model = any> {
-  collection: Collection;
+    collection: Collection;
 
-  private _ctx?: C;
+    private _ctx?: C;
 
-  set ctx(ctx: FlinkContext) {
-    this._ctx = ctx as C;
-  }
+    set ctx(ctx: FlinkContext) {
+        this._ctx = ctx as C;
+    }
 
-  get ctx() {
-    if (!this._ctx) throw new Error("Missing FlinkContext");
-    return this._ctx;
-  }
+    get ctx() {
+        if (!this._ctx) throw new Error("Missing FlinkContext");
+        return this._ctx;
+    }
 
-  constructor(private collectionName: string, private db: Db) {
-    this.collection = db.collection(this.collectionName);
-  }
+    constructor(private collectionName: string, private db: Db) {
+        this.collection = db.collection(this.collectionName);
+    }
 
-  async findAll(query = {}): Promise<Model[]> {
-    return this.collection.find(query).toArray();
-  }
+    async findAll(query = {}): Promise<Model[]> {
+        return this.collection.find(query).toArray();
+    }
 
-  async getById(id: string): Promise<Model | null> {
-    return this.collection.findOne({ _id: new ObjectID(id) });
-  }
+    async getById(id: string): Promise<Model | null> {
+        return this.collection.findOne({ _id: this.buildId(id) });
+    }
 
-  async getOne(query = {}): Promise<Model | null> {
-    return this.collection.findOne(query);
-  }
+    async getOne(query = {}): Promise<Model | null> {
+        return this.collection.findOne(query);
+    }
 
-  async create<C = Omit<Model, "_id">>(model: C): Promise<C & { _id: string }> {
-    const { ops } = await this.collection.insertOne(model);
-    return ops[0];
-  }
+    async create<C = Omit<Model, "_id">>(model: C): Promise<C & { _id: string }> {
+        const { ops } = await this.collection.insertOne(model);
+        return ops[0];
+    }
 
-  async updateOne<U = Partial<Model>>(id: string, model: U): Promise<Model> {
-    const oid = new ObjectID(id);
+    async updateOne<U = Partial<Model>>(id: string, model: U): Promise<Model> {
+        const oid = this.buildId(id);
 
-    await this.collection.updateOne(
-      {
-        _id: oid,
-      },
-      {
-        $set: model,
-      }
-    );
-    return this.collection.findOne({ _id: oid });
-  }
+        await this.collection.updateOne(
+            {
+                _id: oid,
+            },
+            {
+                $set: model,
+            }
+        );
+        return this.collection.findOne({ _id: oid });
+    }
 
-  async updateMany<U = Partial<Model>>(query: any, model: U): Promise<number> {
-    const { modifiedCount } = await this.collection.updateMany(query, {
-      $set: model,
-    });
-    return modifiedCount;
-  }
+    async updateMany<U = Partial<Model>>(query: any, model: U): Promise<number> {
+        const { modifiedCount } = await this.collection.updateMany(query, {
+            $set: model,
+        });
+        return modifiedCount;
+    }
 
-  async deleteById(id: string): Promise<number> {
-    const { deletedCount } = await this.collection.deleteOne({
-      _id: new ObjectID(id),
-    });
-    return deletedCount || 0;
-  }
+    async deleteById(id: string): Promise<number> {
+        const { deletedCount } = await this.collection.deleteOne({
+            _id: this.buildId(id),
+        });
+        return deletedCount || 0;
+    }
+
+    private buildId(id: string | ObjectId) {
+        let oid: ObjectId | string;
+
+        if (typeof id === "string") {
+            oid = ObjectId.isValid(id) ? new ObjectId(id) : id;
+        } else if (id instanceof ObjectId) {
+            oid = id;
+        } else {
+            throw new Error("Invalid id type");
+        }
+    }
 }


### PR DESCRIPTION
Allow to use string and ObjectId in FlinkRepo methods. 