### PR TITLE
[ FIX ] Add additional fields to UserPasswordResetStart

### DIFF
--- a/packages/generic-auth-plugin/src/handlers/UserPasswordResetStart.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserPasswordResetStart.ts
@@ -38,6 +38,8 @@ const postPasswordResetStartHandler: Handler<
         passwordResetToken: resp.passwordResetToken,
         username: req.body.username,
         profile: resp.profile,
+        type: req.body.type,
+        additionalAuth: req.body.additionalAuth,
     };
 
     let emailSettings = genericAuthPlugin.passwordResetSettings.email;

--- a/packages/generic-auth-plugin/src/schemas/UserPasswordResetStartReq.ts
+++ b/packages/generic-auth-plugin/src/schemas/UserPasswordResetStartReq.ts
@@ -1,3 +1,5 @@
 export interface UserPasswordResetStartReq{
-    username : string
+    username : string;
+    type?: string;
+    additionalAuth?: string;
 }


### PR DESCRIPTION
Adds two additional fields to `UserPasswordRequestStart` handler, and passes them on to `emailSettings` callback.

Background is that there is a need to send password reset emails with different content.
Different types can be distinguished via `type`
Idea with `additionalAuth` is to be able to control who calls the handler. Maybe some `type` should only be possible to use via server-to-server, for example.