### PR TITLE
[ FIX ] Extract inline script to own url to avoid content-security-policy warning

### DIFF
--- a/packages/generic-auth-plugin/src/handlers/UserPasswordResetForm.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserPasswordResetForm.ts
@@ -38,8 +38,26 @@ const defaultTemplate = `<html>
       max-width: 350px;
     }
   </style>
-  <script>
-    window.onload = () => {
+  <script src="form/script.js" type="text/javascript"></script>
+</head>
+<body>
+  <form id="form">
+    <p>Please enter new password</p>
+    <input type="password" name="password" placeholder="Enter new password" />
+    <input
+      type="password"
+      name="confirmPassword"
+      placeholder="Confirm new password"
+    />
+    <button id="submit-btn">Submit</button>
+  </form>
+  <div id="success">Password has been updated, please proceed to login.</div>
+</body>
+</html>
+`;
+
+const script = `
+      window.onload = () => {
       const urlSearchParams = new URLSearchParams(window.location.search);
       const params = Object.fromEntries(urlSearchParams.entries());
       const { token, code } = params;
@@ -87,22 +105,6 @@ const defaultTemplate = `<html>
         }
       };
     };
-  </script>
-</head>
-<body>
-  <form id="form">
-    <p>Please enter new password</p>
-    <input type="password" name="password" placeholder="Enter new password" />
-    <input
-      type="password"
-      name="confirmPassword"
-      placeholder="Confirm new password"
-    />
-    <button id="submit-btn">Submit</button>
-  </form>
-  <div id="success">Password has been updated, please proceed to login.</div>
-</body>
-</html>
 `;
 
 export async function handleUserPasswordResetForm(
@@ -117,6 +119,12 @@ export async function handleUserPasswordResetForm(
   });
 
   res.send(html);
+}
+
+export async function resetPasswordFormScript(req: ExpressRequest, res: ExpressResponse, { completeUrl }: { completeUrl: string }) {
+    res.header("Content-Type", "application/javascript");
+    const js = Handlebars.compile(script)({completeUrl});
+    res.send(js);
 }
 
 let cachedTemplate = "";

--- a/packages/generic-auth-plugin/src/init.ts
+++ b/packages/generic-auth-plugin/src/init.ts
@@ -11,7 +11,7 @@ import { GenericAuthPluginOptions } from "./genericAuthPluginOptions";
 import * as postUserPushRegisterTokenHandler from "./handlers/UserPushRegisterToken";
 import * as postUserRemoveTokenHandler from "./handlers/UserPushRemoveToken";
 import * as getUserTokenHandler from "./handlers/UserToken";
-import { handleUserPasswordResetForm } from "./handlers/UserPasswordResetForm";
+import { handleUserPasswordResetForm, resetPasswordFormScript } from "./handlers/UserPasswordResetForm";
 
 export function init(app: FlinkApp<any>, options: GenericAuthPluginOptions) {
   if (options.enableUserCreation == null) options.enableUserCreation = true;
@@ -106,6 +106,12 @@ export function init(app: FlinkApp<any>, options: GenericAuthPluginOptions) {
               templateFile: options.passwordResetSettings?.passwordResetForm,
               completeUrl: options.baseUrl + "/password/reset/complete",
             })
+        );
+        app.expressApp?.get(
+            options.baseUrl + "/password/reset/form/script.js",
+            (req, res) => {
+              resetPasswordFormScript(req, res, { completeUrl: options.baseUrl + "/password/reset/complete", });
+            }
         );
       }
     }


### PR DESCRIPTION
content-security-policy header can prohibit inline scripts (learned this the hard way 😅 ) - this moves the javascript for the default password-reset-form into a separate url, to avoid this.