### PR TITLE
[ FIX ] add option to make password-reset-tokens valid only once

### DIFF
--- a/packages/generic-auth-plugin/src/genericAuthContext.ts
+++ b/packages/generic-auth-plugin/src/genericAuthContext.ts
@@ -18,8 +18,8 @@ export interface genericAuthContext{
         loginByToken(repo: FlinkRepo<any, User>, auth: JwtAuthPlugin, token : string, code : string,  jwtSecret : string) : Promise<UserLoginRes>,
         createUser( repo : FlinkRepo<any, User>, auth : JwtAuthPlugin, username : string, password : string, authentificationMethod : "password" | "sms",  roles : string[], profile : UserProfile, createPasswordHashAndSaltMethod? : { (password : string) : Promise<{ hash: string; salt: string;} | null>  }  ) : Promise<UserCreateRes>,
         changePassword( repo : FlinkRepo<any, User>, auth : JwtAuthPlugin, userId : string, newPassword : string, createPasswordHashAndSaltMethod? : { (password : string) : Promise<{ hash: string; salt: string;} | null>  } ) : Promise<UserPasswordChangeRes>,
-        passwordResetStart( repo : FlinkRepo<any, User>, auth : JwtAuthPlugin, jwtSecret : string, username : string, numberOfDigits? : number, lifeTime? : string) : Promise<UserPasswordResetStartRes>,
-        passwordResetComplete( repo : FlinkRepo<any, User>, auth : JwtAuthPlugin, jwtSecret : string, passwordResetToken : string, code : string, newPassword : string, createPasswordHashAndSaltMethod? : { (password : string) : Promise<{ hash: string; salt: string;} | null>  } ) : Promise<UserPasswordResetCompleteRes>         
+        passwordResetStart( repo : FlinkRepo<any, User>, auth : JwtAuthPlugin, jwtSecret : string, username : string, numberOfDigits? : number, lifeTime? : string, passwordResetReusableTokens?:boolean) : Promise<UserPasswordResetStartRes>,
+        passwordResetComplete( repo : FlinkRepo<any, User>, auth : JwtAuthPlugin, jwtSecret : string, passwordResetToken : string, code : string, newPassword : string, createPasswordHashAndSaltMethod? : { (password : string) : Promise<{ hash: string; salt: string;} | null>  }, passwordResetReusableTokens?:boolean ) : Promise<UserPasswordResetCompleteRes>
         repoName : string,
         passwordResetSettings? : UserPasswordResetSettings,
         createPasswordHashAndSaltMethod? : { (password : string) : Promise<{ hash: string; salt: string;} | null>  },

--- a/packages/generic-auth-plugin/src/genericAuthPluginOptions.ts
+++ b/packages/generic-auth-plugin/src/genericAuthPluginOptions.ts
@@ -5,6 +5,7 @@ export interface GenericAuthPluginOptions {
     repoName: string;
     enableRoutes?: boolean;
     enablePasswordReset?: boolean;
+    passwordResetReusableTokens?: boolean;
     enablePushNotificationTokens?: boolean;
     passwordResetSettings?: UserPasswordResetSettings;
     enableUserCreation?: boolean;

--- a/packages/generic-auth-plugin/src/handlers/UserPasswordResetComplete.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserPasswordResetComplete.ts
@@ -34,7 +34,8 @@ const postPasswordResetCompleteHandler: Handler<
     req.body.passwordResetToken,
     req.body.code,
     req.body.password,
-    ctx.plugins.genericAuthPlugin.createPasswordHashAndSaltMethod
+    ctx.plugins.genericAuthPlugin.createPasswordHashAndSaltMethod,
+    ctx.plugins.genericAuthPlugin.passwordResetSettings.passwordResetReusableTokens
   );
 
   switch (resp.status) {

--- a/packages/generic-auth-plugin/src/handlers/UserPasswordResetStart.ts
+++ b/packages/generic-auth-plugin/src/handlers/UserPasswordResetStart.ts
@@ -27,7 +27,7 @@ const postPasswordResetStartHandler: Handler<
 
     const { jwtSecret, numberOfDigits, lifeTime } = genericAuthPlugin.passwordResetSettings.code;
 
-    const resp = await genericAuthPlugin.passwordResetStart(repo, <JwtAuthPlugin>ctx.auth, jwtSecret, req.body.username, numberOfDigits, lifeTime);
+    const resp = await genericAuthPlugin.passwordResetStart(repo, <JwtAuthPlugin>ctx.auth, jwtSecret, req.body.username, numberOfDigits, lifeTime, genericAuthPlugin.passwordResetSettings.passwordResetReusableTokens);
 
     if (resp.status != "success") {
       return { data: { status: "success", passwordResetToken: resp.passwordResetToken } };

--- a/packages/generic-auth-plugin/src/schemas/User.ts
+++ b/packages/generic-auth-plugin/src/schemas/User.ts
@@ -8,6 +8,7 @@ export interface User {
     password?: string;
     salt? : string;
 
+    pwdResetStartedAt?: string;
     roles: string[];
     
     authentificationMethod : "password" | "sms";

--- a/packages/generic-auth-plugin/src/schemas/UserPasswordResetSettings.ts
+++ b/packages/generic-auth-plugin/src/schemas/UserPasswordResetSettings.ts
@@ -23,5 +23,6 @@ export interface UserPasswordResetSettings {
     enablePasswordResetForm?: boolean;
     passwordResetForm?: string;
     resetPasswordFormBaseUrl?: string;
+    passwordResetReusableTokens?: boolean;
 
 }


### PR DESCRIPTION
Adds the option to make password-reset-tokens one-time-use only, by setting config `passwordResetReusableTokens` to `false` (keeping it at `true` by default)

Adds optional field `pwdResetStartedAt`, which is populated with a timestamp when the reset is initiated. This timestamp is then concatenated with the jwt-secret in the format:

`{jwt_secret}:{code}:{pwdResetStartedAt}`

And then used to sign the jwt.
Upon completing the password reset, `pwdResetStartedAt` is fetched from the user in database, and then used to validate jwt token. If password reset is successful, `pwdResetStartedAt` is set to `null` on user in database.

imho, this gives 2 improvements:

1. tokens are invalidated after use.
2. requesting a new password reset will invalidate any previous tokens (because `pwdResetStartedAt` is updated), only one token per user can be valid at any time.

The `exp` time still applies, so an unused token also becomes invalid after this.